### PR TITLE
feat: add TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,12 @@ policy would be applied when the evidence for that scheme is appraised by the
 verification service:
 
     ./pocli deactivate PSA_IOT
+
+### Note on TLS
+
+`-s`/`--tls` flag can be used to enable TLS, in which case system CA certs will
+be used to validate the certificate sent by the server. It is possible to
+disable server certificate validation with `-i`/`--insecure` flag (note that if
+this flag is used, `-s` flag is implied and does not need to be explicitly specified.
+specified). Alternatively, if the CA cert for the server is available but is
+not installed in the system, it may be specified using `-E`/`--ca-cert` flag.

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.20
 require (
 	github.com/google/uuid v1.3.0
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
-	github.com/veraison/apiclient v0.2.0
+	github.com/veraison/apiclient v0.2.1-0.20240531100343-8a3a730a1e94
 )
 
 require (
@@ -21,7 +22,6 @@ require (
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	golang.org/x/net v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
-github.com/veraison/apiclient v0.2.0 h1:QELvZ+eEfzh9v0ORe9B2UTMpiA7aONHpZIfwSfcRR6s=
-github.com/veraison/apiclient v0.2.0/go.mod h1:LCXFZ3D/tJ3HLAOHUg8bnAKGvgTl53e1ntwdwjVbQ5A=
+github.com/veraison/apiclient v0.2.1-0.20240531100343-8a3a730a1e94 h1:0d7vTs3K9Y4bskTtI3pvkFE0HiSHc4vWA3M6Fc0lWRM=
+github.com/veraison/apiclient v0.2.1-0.20240531100343-8a3a730a1e94/go.mod h1:LCXFZ3D/tJ3HLAOHUg8bnAKGvgTl53e1ntwdwjVbQ5A=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
- Add -s/--tls flag to indicate that TLS should be used when connecting to the service
- Add -i/--insecure flag to indicate that server cert checks should be skipped
- Add -E/--ca-cert flag to specify additional CA cert(s) to be used in server cert validation (system CA certs are used by default).