### PR TITLE
fix: propagate ca_cert to OAuth2 authenticator

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -125,6 +125,7 @@ func initConfig() {
 			"token_url":     v.GetString("token_url"),
 			"username":      v.GetString("username"),
 			"password":      v.GetString("password"),
+			"ca_certs":      v.GetStringSlice("ca_cert"),
 		})
 		cobra.CheckErr(err)
 	default:

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
-	github.com/veraison/apiclient v0.2.1-0.20240531100343-8a3a730a1e94
+	github.com/veraison/apiclient v0.3.1-0.20240807160142-9141ad363e45
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
-github.com/veraison/apiclient v0.2.1-0.20240531100343-8a3a730a1e94 h1:0d7vTs3K9Y4bskTtI3pvkFE0HiSHc4vWA3M6Fc0lWRM=
-github.com/veraison/apiclient v0.2.1-0.20240531100343-8a3a730a1e94/go.mod h1:LCXFZ3D/tJ3HLAOHUg8bnAKGvgTl53e1ntwdwjVbQ5A=
+github.com/veraison/apiclient v0.3.1-0.20240807160142-9141ad363e45 h1:o+gCzGtusXZOOXuJavzvpraSk8ify4U60Aq9r/4vOho=
+github.com/veraison/apiclient v0.3.1-0.20240807160142-9141ad363e45/go.mod h1:LCXFZ3D/tJ3HLAOHUg8bnAKGvgTl53e1ntwdwjVbQ5A=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Use ca_cert certs when configuring the OAuth2 authenticator, in addition to their current use in connection to the API service.