### PR TITLE
chore: change default port to 10443

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "configuration file")
 	rootCmd.PersistentFlags().StringP("host", "H", "localhost",
 		"the host running Veraison management service")
-	rootCmd.PersistentFlags().IntP("port", "p", 8088,
+	rootCmd.PersistentFlags().IntP("port", "p", 10443,
 		"the port on which Veraison management service is listening")
 	rootCmd.PersistentFlags().VarP(&authMethod, "auth", "a",
 		`authentication method, must be one of "none"/"passthrough", "basic", "oauth2"`)

--- a/misc/example-config.yaml
+++ b/misc/example-config.yaml
@@ -1,6 +1,6 @@
 # Remote service location
 host: localhost
-port: 8088
+port: 10443
 
 # Authentication method used by the remote service.
 auth: none  # may also be "basic" or "oauth2"


### PR DESCRIPTION
Since TLS is enabled by default, default ports for services have switched to reflect that fact.

This updates the default in the client to be in line with the corresponding service.
